### PR TITLE
Hotfix/Plainset

### DIFF
--- a/structured/cache/engine.py
+++ b/structured/cache/engine.py
@@ -233,7 +233,7 @@ class CacheEngine:
         plainset = defaultdict(set)
         for model, tuples in fk_data.items():
             for t in tuples:
-                if isinstance(t[1], Sequence):
+                if isinstance(t[1], (list, tuple, set, frozenset)):
                     plainset[model].update(t[1])
                 else:
                     plainset[model].add(t[1])


### PR DESCRIPTION
Overview:
This PR is to fix an unexpected behavior when one single FK relationship with uuid/str as PK is passed through.

Background:
A uuid/string PK would be mistakenly judged as "Sequence" thus be broken down into single characters as the FK model's IDs.
As the result, the subsequent django validation process will then report errors.

Solution:
Use valid iterable types explicitly, instead of using `Sequence`, which is too "broad".
`if isinstance(t[1], Sequence):` should be changed to if `isinstance(t[1], (list, tuple, set, frozenset)):`.

Suggestions:
Add another test model with uuid/str as PK for a better coverage.

Related issue:
#8 